### PR TITLE
Resolve FutureWarning in skimage.filters.median

### DIFF
--- a/whitening/__init__.py
+++ b/whitening/__init__.py
@@ -91,7 +91,7 @@ def whiten(image, kernel_size=10, downsample=1):
         """
         image_channel = input_image[:, :, channel_index]
         if channel_index < 3:
-            return skimage.filters.median(image_channel, selem=kernel)
+            return skimage.filters.median(image_channel, footprint=kernel)
         else:
             # do not filter alpha channel
             return image_channel


### PR DESCRIPTION
Get rid of the following warning:
```
  /Users/stepan.simsa/code/whitening/whitening/__init__.py:94: FutureWarning: `selem` is a deprecated argument name for `median`. It will be removed in version 1.0. Please use `footprint` instead.
    return skimage.filters.median(image_channel, selem=kernel)
```

Tests pass and it works fine on the example image.